### PR TITLE
Verify env recipes + README updates + per-pipeline READMEs

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -19,6 +19,10 @@ Example 1: demo (basic)
    - just preview  or  just stub  or  just test
 6) Run (offline)
    - just down; just run
+8) Verify environment
+   - just verify_env; just verify_config
+7) Verify environment
+   - just verify_env; just verify_config
 
 Example 2: rnaseq (complex)
 1) Pick quay-only revision (manual, one-time)
@@ -37,6 +41,8 @@ Example 2: rnaseq (complex)
    - just preview  or  just stub  or  just test
 7) Run (offline)
    - just down; just run
+7) Verify environment
+   - just verify_env; just verify_config
 
 Notes
 - Always: source ~/.env; source ENV before running `just` or `setup.sh`.

--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ ENV Expectations
 - Optional: `PLUGINS_S3=s3://lifebit-user-data-nextflow/pipe/plugins/`
 
 Plugins (optional)
-- Dev install + upload: create `plugins.list` (CSV of plugins), then:
-  - `PLUGINS_S3=... just plugins_install`
+- Dev install + upload:
+  - `nextflow plugin install nf-amazon@<ver>,nf-validation@<ver>,nf-prov@<ver>`
+  - `aws s3 sync "$HOME/.nextflow/plugins/" "$PLUGINS_S3"`
 - Offline sync:
-  - `PLUGINS_S3=... just plugins_sync`
+  - `aws s3 sync "$PLUGINS_S3" "$HOME/.nextflow/plugins"`
 
 Choosing a Quay‑only Revision (manual, one‑time)
 - `bash common/quay/select_quay_revision.sh --pipeline sarek`
@@ -53,6 +54,7 @@ Notes
   `--custom_config_base null --custom_config_version null --pipelines_testdata_base_path null`
 - Use `--follow-symlinks` in S3 sync to avoid stale symlink stubs.
 - For offline hosts, ensure Nexus Proxy access to quay is working (pre‑validated).
+ - Nextflow version pinning (set in `~/.env` if desired): Dev=`24.04.4`, Prod=`24.10.5`.
 
 More
 - See GETTING_STARTED.md for step‑by‑step demos (demo + rnaseq).

--- a/bamtofastq/README.md
+++ b/bamtofastq/README.md
@@ -1,0 +1,11 @@
+# bamtofastq — Quick Start (KISS)
+
+- source ~/.env; source ENV
+- (Optional pin) export NXF_VER=24.04.4
+- ./setup.sh -f; cd bamtofastq
+- diff -u ../test.config conf/test.config || echo "OK: symlink"
+- just check_data
+- Online: just preview  (or: just stub / just test)
+- Offline: just down; just run
+- Optional data refresh: bash ../../common/data/mirror_testdata.sh --rows 1 --param-name input --conf ./conf/test.config
+- Quay tag (one-time): bash ../../common/quay/select_quay_revision.sh --pipeline bamtofastq

--- a/common/pipeline/justfile
+++ b/common/pipeline/justfile
@@ -75,3 +75,20 @@ clean:
     nextflow clean -f; rm -rf /tmp/nxf-work/ .nextflow null
 
 ## (Plugins and Quay helper recipes removed by request; use simple shell commands instead.)
+
+# Verify environment (NXF_VER, PIPELINE, REVISION, S3/ROOT, NXF paths)
+verify_env:
+    @set -euo pipefail; \
+    echo "PIPELINE=${PIPELINE:-}"; \
+    echo "REVISION=${REVISION:-}"; \
+    echo "S3_ROOT=${S3_ROOT:-}"; \
+    echo "ROOT_DIR=${ROOT_DIR:-}"; \
+    echo "NXF_HOME=${NXF_HOME:-$HOME/.nextflow}"; \
+    echo "NXF_WORK=${NXF_WORK:-}"; \
+    echo "NXF_VER=${NXF_VER:-(unset)}"; \
+    nextflow -version || true
+
+# Verify test.config symlink
+verify_config:
+    @set -euo pipefail; \
+    if [ -L conf/test.config ]; then echo "[✔] conf/test.config is symlink -> $$(readlink conf/test.config)"; else echo "[x] conf/test.config is not a symlink"; exit 1; fi

--- a/sarek/README.md
+++ b/sarek/README.md
@@ -1,0 +1,11 @@
+# sarek — Quick Start (KISS)
+
+- source ~/.env; source ENV
+- (Optional pin) export NXF_VER=24.04.4
+- ./setup.sh -f; cd sarek
+- diff -u ../test.config conf/test.config || echo "OK: symlink"
+- just check_data
+- Online: just preview  (or: just stub / just test)
+- Offline: just down; just run
+- Optional data refresh: bash ../../common/data/mirror_testdata.sh --rows 1 --param-name input --conf ./conf/test.config
+- Quay tag (one-time): bash ../../common/quay/select_quay_revision.sh --pipeline sarek


### PR DESCRIPTION
Add common verify_env and verify_config recipes.\nUpdate README/GETTING_STARTED for Nextflow version pin (Dev=24.04.4, Prod=24.10.5) and replace plugin commands with simple aws sync instructions.\nAdd minimal READMEs for sarek and bamtofastq.\n\nTest: ran just verify_env and verify_config locally; docs updated accordingly.